### PR TITLE
Tabs renderItem fix

### DIFF
--- a/docs/group.mdx
+++ b/docs/group.mdx
@@ -29,17 +29,17 @@ import Col from '@emcasa/ui-dom/components/Col'
   </RadioButton.Group>
 </Playground>
 
-## renderOption
+## renderItem
 
 All children on a Group must be an instance of it's base component, or at least work with the same props.
-use `renderOption` to render components around each child.
+use `renderItem` to render components around each child.
 
 <Playground>
   <Text>With option wrapper</Text>
   <Button.Group
     initialValue="b"
     onChange={(values) => console.log('selected', values)}
-    renderOption={(option, props) => <Col width={1/4} m={4}>{option}</Col>}>
+    renderItem={(option, props) => <Col width={1/4} m={4}>{option}</Col>}>
     <Button fluid value="a">Button A</Button>
     <Button fluid value="b">Button B</Button>
     <Button fluid value="c">Button C</Button>

--- a/packages/ui/src/components/Group/index.js
+++ b/packages/ui/src/components/Group/index.js
@@ -66,7 +66,7 @@ const Group = (parseProps, getValue = defaultGetValue) => (Target) =>
       selectedValue: PropTypes.any,
       disabled: PropTypes.bool,
       onChange: PropTypes.func,
-      renderOption: PropTypes.func,
+      renderItem: PropTypes.func,
       ...(Target.propTypes || {})
     }
 
@@ -131,13 +131,13 @@ const Group = (parseProps, getValue = defaultGetValue) => (Target) =>
     }
 
     renderChild = (child, index) => {
-      const {renderOption} = this.props
+      const {renderItem} = this.props
       if (!child) return
       const component = React.cloneElement(
         child,
         this._childProps(child, index)
       )
-      if (renderOption) return renderOption(component, this.props)
+      if (renderItem) return renderItem(component, this.props)
       return component
     }
 

--- a/packages/ui/src/components/Group/index.js
+++ b/packages/ui/src/components/Group/index.js
@@ -1,3 +1,4 @@
+import {Fragment} from 'react'
 import toArray from 'lodash.toarray'
 import omit from 'lodash.omit'
 import React, {PureComponent} from 'react'
@@ -33,6 +34,12 @@ export const Strategies = {
 }
 
 const defaultGetValue = ({value}) => value
+
+class GroupItem extends PureComponent {
+  render() {
+    return <Fragment>{this.props.children}</Fragment>
+  }
+}
 
 const Group = (parseProps, getValue = defaultGetValue) => (Target) =>
   class SelectGroup extends PureComponent {
@@ -130,21 +137,26 @@ const Group = (parseProps, getValue = defaultGetValue) => (Target) =>
       return omit(nextProps, Object.keys(node.props))
     }
 
-    renderChild = (child, index) => {
+    renderItem = (child, index) => {
       const {renderItem} = this.props
       if (!child) return
       const component = React.cloneElement(
         child,
         this._childProps(child, index)
       )
-      if (renderItem) return renderItem(component, this.props)
-      return component
+      // Wrap item to ensure the Target component has access to child props
+      // when `renderItem` is passed
+      return (
+        <GroupItem {...component.props}>
+          {renderItem ? renderItem(component, this.props) : component}
+        </GroupItem>
+      )
     }
 
     render() {
       return (
         <Target {...this.props} {...this.state} onSelect={this.onChange}>
-          {React.Children.map(this.props.children, this.renderChild)}
+          {React.Children.map(this.props.children, this.renderItem)}
         </Target>
       )
     }


### PR DESCRIPTION
This PR fixes an issue with the `Tabs` component throwing errors when `renderItem` prop is passed.