### PR TITLE
Replace Object.values with Object.keys

### DIFF
--- a/packages/ui/src/components/Icon/hoc.js
+++ b/packages/ui/src/components/Icon/hoc.js
@@ -5,7 +5,8 @@ import {ICON_SIZE} from '../../theme/measures'
 const getIcon = ({type, name}, {icons, defaultIcon}) => {
   const findIcon = (iconName, key = type) => {
     if (!(key in icons)) return undefined
-    for (const icon of Object.values(icons[key]))
+    const values = Object.keys(icons[key]).map((item) => icons[key][item])
+    for (const icon of values)
       if (icon.iconName == iconName) return icon
   }
   const icon = findIcon(name) || findIcon(defaultIcon, 'default')


### PR DESCRIPTION
`Object.values` is not supported in some older browsers, such as mobile Android 4.4. This PR replaces it with `Object.keys`.