### PR TITLE
Filter fixes

### DIFF
--- a/packages/ui-dom/src/Filters/ListingFilters.js
+++ b/packages/ui-dom/src/Filters/ListingFilters.js
@@ -82,12 +82,16 @@ const formatNumRange = (noun) => {
   })
 }
 
-const formatPriceRange = formatSliderRange(
-  (value) =>
-    `R$ ${abbrev(value, 2)
-      .toString()
-      .toUpperCase()
-      .replace('.', ',')}`
+const formatPrice = (value) =>
+  `R$ ${abbrev(value, 2)
+    .toString()
+    .toUpperCase()
+    .replace('.', ',')}`
+
+const formatPriceRange = formatSliderRange(formatPrice)
+
+const formatPricePerAreaRange = formatSliderRange(
+  (value) => `${formatPrice(value)}/m²`
 )
 
 const formatAreaRange = formatSliderRange((value) => `${value} m²`)
@@ -124,7 +128,7 @@ const PricePerAreaFilter = ({...props}) => (
     }
     formatLabel={cond([
       [not(hasValue), () => 'Preço/m²'],
-      [stubTrue, formatPriceRange(props.range)]
+      [stubTrue, formatPricePerAreaRange(props.range)]
     ])}
     {...props}
   />

--- a/packages/ui-dom/src/Filters/SliderRangeFilter.js
+++ b/packages/ui-dom/src/Filters/SliderRangeFilter.js
@@ -15,8 +15,10 @@ export class SliderRange extends PureComponent {
       formatLabel
     } = this.props
     const displayValue = Object.assign({}, currentValue || initialValue)
-    if (displayValue.min === undefined) displayValue.min = range[0]
-    if (displayValue.max === undefined) displayValue.max = range[1]
+    if (isNaN(displayValue.min) || displayValue.min === null)
+      displayValue.min = range[0]
+    if (isNaN(displayValue.max) || displayValue.max === null)
+      displayValue.max = range[1]
     return (
       <View pr={2} pl={2}>
         {formatLabel && (

--- a/packages/ui-dom/src/Filters/index.js
+++ b/packages/ui-dom/src/Filters/index.js
@@ -265,6 +265,7 @@ const FilterGroup = Group(
                 ref={this.contentRef}
                 visible={Boolean(selectedValue)}
                 row={{expanded: isRowExpanded, visible: isRowVisible}}
+                offset={bodyHeight}
               />
               <Background
                 pose={selectedValue ? 'bgOpen' : 'bgClosed'}


### PR DESCRIPTION
* Fix expanded filter height on mobile
* Change `pricePerArea` filter formatting to `R${price}/m²` to distinguish from the `price` filter
* Fix a bug in SliderRangeFilter when either `min` or `max` initial values are null