### PR TITLE
Add icon set factory

### DIFF
--- a/packages/ui-dom/src/Icon/index.js
+++ b/packages/ui-dom/src/Icon/index.js
@@ -14,7 +14,11 @@ const IconComponent = styled(
         x={0}
         y={0}
       >
-        <path d={icon.path} fill={color} {...props} />
+        {icon.render ? (
+          icon.render({...props, color})
+        ) : (
+          <path d={icon.path} fill={color} {...icon.props} {...props} />
+        )}
       </svg>
     </div>
   ))

--- a/packages/ui/src/components/Icon/hoc.js
+++ b/packages/ui/src/components/Icon/hoc.js
@@ -2,15 +2,17 @@ import React from 'react'
 import {withTheme} from 'styled-components'
 import {ICON_SIZE} from '../../theme/measures'
 
-const getIcon = ({type, name}, {icons, defaultIcon}) => {
+const getIcon = (props, {icons, defaultIcon}) => {
+  const {type, name} = props
   const findIcon = (iconName, key = type) => {
     if (!(key in icons)) return undefined
     const values = Object.keys(icons[key]).map((item) => icons[key][item])
-    for (const icon of values)
-      if (icon.iconName == iconName) return icon
+    for (const icon of values) if (icon.iconName == iconName) return icon
   }
   const icon = findIcon(name) || findIcon(defaultIcon, 'default')
   return {
+    props: typeof icon.props === 'function' ? icon.props(props) : icon.props,
+    render: icon.render,
     width: icon.icon[0],
     height: icon.icon[1],
     path: icon.icon[4]

--- a/packages/ui/src/styles/createIconSet.js
+++ b/packages/ui/src/styles/createIconSet.js
@@ -1,0 +1,15 @@
+export function Icon(iconName, {props = {}, render, path, width, height}) {
+  return {
+    iconName,
+    props,
+    render,
+    icon: [width, height, [], '', path]
+  }
+}
+
+export default function IconSet(icons) {
+  return Object.entries(icons).reduce(
+    (icons, [name, def]) => ({...icons, [name]: Icon(name, def)}),
+    {}
+  )
+}


### PR DESCRIPTION
This PR adds helper functions to create icon sets to use with the `Icon` component.
Example usage:

```jsx
import theme from '@emcasa/ui'
import IconSet from '@emcasa/ui/lib/styles/createIconSet'

const myIcons = IconSet({
	foo: {
		// Svg bounding box size
		height: 50,
		width: 50,
		render: () => <path d="..." />
	},
	bar: {
		height: 50,
		width: 50,
		path: '...'
	}
})

const myTheme = {
	...theme,
	icons: {myIcons}
}
```
-------
```jsx
<Icon name="foo" type="myIcons" size={16} />
```
