### PR TITLE
Improve map control props

### DIFF
--- a/packages/ui-dom/src/Map/ButtonControl/index.js
+++ b/packages/ui-dom/src/Map/ButtonControl/index.js
@@ -12,6 +12,8 @@ export default function ButtonControl({
   mr,
   ml,
   zIndex,
+  index,
+  onControlReady,
   ...props
 }) {
   return (
@@ -25,7 +27,9 @@ export default function ButtonControl({
         mb,
         mr,
         ml,
-        zIndex
+        zIndex,
+        index,
+        onControlReady
       }}
     >
       <Button {...props} />

--- a/packages/ui-dom/src/Map/Context.js
+++ b/packages/ui-dom/src/Map/Context.js
@@ -20,10 +20,12 @@ export {Consumer, Provider}
 
 export const withMapContext = (mapStateToProps) => (Target) =>
   hoistStatics(
-    (props) => (
+    React.forwardRef((props, ref) => (
       <Consumer>
-        {(ctx) => <Target {...props} {...mapStateToProps(ctx, props)} />}
+        {(ctx) => (
+          <Target ref={ref} {...props} {...mapStateToProps(ctx, props)} />
+        )}
       </Consumer>
-    ),
+    )),
     Target
   )

--- a/packages/ui-dom/src/Map/Control/index.js
+++ b/packages/ui-dom/src/Map/Control/index.js
@@ -38,10 +38,15 @@ class MapControl extends PureComponent {
   }
 
   registerControl(position) {
-    const {map, index} = this.props
+    const {map, index, onControlReady} = this.props
     this.controlIndex = map.controls[position].length
     if (!isNaN(index)) this.control.index = index
     map.controls[position].push(this.control)
+    if (onControlReady)
+      onControlReady({
+        control: this.control,
+        element: map.controls[position].getAt(this.controlIndex)
+      })
   }
 
   unregisterControl(position) {
@@ -72,6 +77,8 @@ class MapControl extends PureComponent {
     delete props.position
     delete props.map
     delete props.maps
+    delete props.onControlReady
+    delete props.index
     if (!this.control) return null
     return ReactDOM.createPortal(
       <View {...props}>{children}</View>,

--- a/packages/ui-dom/src/Map/SelectControl/index.js
+++ b/packages/ui-dom/src/Map/SelectControl/index.js
@@ -67,10 +67,11 @@ export class SelectInput extends PureComponent {
       children,
       onChange,
       selectedValue,
-      strategy
+      strategy,
+      zIndex
     } = this.props
     const {expanded, listHeight} = this.state
-    const buttonProps = {height, fontSize}
+    const buttonProps = {height, fontSize, zIndex}
     const groupProps = {strategy, onChange, selectedValue}
     return (
       <Container
@@ -103,9 +104,23 @@ export default function SelectControl({
   mr,
   ml,
   zIndex,
+  index,
+  onControlReady,
   ...props
 }) {
-  const controlProps = {position, style, className, m, mt, mb, mr, ml, zIndex}
+  const controlProps = {
+    position,
+    style,
+    className,
+    m,
+    mt,
+    mb,
+    mr,
+    ml,
+    zIndex,
+    index,
+    onControlReady
+  }
   return (
     <Control {...controlProps}>
       <SelectInput {...props} />

--- a/packages/ui-dom/src/Map/SelectControl/index.js
+++ b/packages/ui-dom/src/Map/SelectControl/index.js
@@ -36,7 +36,7 @@ function SelectCheckbox({children, ...props}) {
   )
 }
 
-export default class SelectControl extends PureComponent {
+export class SelectInput extends PureComponent {
   static Option = SelectOption
 
   static Checkbox = SelectCheckbox
@@ -61,15 +61,6 @@ export default class SelectControl extends PureComponent {
 
   render() {
     const {
-      style,
-      className,
-      position,
-      m,
-      mt,
-      mb,
-      mr,
-      ml,
-      zIndex,
       height,
       fontSize,
       label,
@@ -79,28 +70,49 @@ export default class SelectControl extends PureComponent {
       strategy
     } = this.props
     const {expanded, listHeight} = this.state
-    const controlProps = {position, style, className, m, mt, mb, mr, ml, zIndex}
     const buttonProps = {height, fontSize}
     const groupProps = {strategy, onChange, selectedValue}
     return (
-      <Control {...controlProps}>
-        <Container
-          height={height}
-          onMouseEnter={this.onMouseEnter}
-          onMouseLeave={this.onMouseLeave}
-        >
-          <Button expanded={expanded} {...buttonProps}>
-            {label}
-          </Button>
-          <List offset={height} expanded={expanded} height={listHeight}>
-            <div ref={this.listRef}>
-              <OptionGroup {...buttonProps} {...groupProps}>
-                {children}
-              </OptionGroup>
-            </div>
-          </List>
-        </Container>
-      </Control>
+      <Container
+        height={height}
+        onMouseEnter={this.onMouseEnter}
+        onMouseLeave={this.onMouseLeave}
+      >
+        <Button expanded={expanded} {...buttonProps}>
+          {label}
+        </Button>
+        <List offset={height} expanded={expanded} height={listHeight}>
+          <div ref={this.listRef}>
+            <OptionGroup {...buttonProps} {...groupProps}>
+              {children}
+            </OptionGroup>
+          </div>
+        </List>
+      </Container>
     )
   }
 }
+
+export default function SelectControl({
+  style,
+  className,
+  position,
+  m,
+  mt,
+  mb,
+  mr,
+  ml,
+  zIndex,
+  ...props
+}) {
+  const controlProps = {position, style, className, m, mt, mb, mr, ml, zIndex}
+  return (
+    <Control {...controlProps}>
+      <SelectInput {...props} />
+    </Control>
+  )
+}
+
+SelectControl.Option = SelectOption
+
+SelectControl.Checkbox = SelectCheckbox

--- a/packages/ui-dom/src/Map/SelectControl/styles.js
+++ b/packages/ui-dom/src/Map/SelectControl/styles.js
@@ -1,6 +1,6 @@
 import curry from 'lodash/curry'
 import styled from 'styled-components'
-import {themeGet} from 'styled-system'
+import {themeGet, zIndex} from 'styled-system'
 import {buttonHeight} from '@emcasa/ui/lib/styles'
 import BaseButton from '../../Button'
 
@@ -46,4 +46,5 @@ export const Button = styled(BaseButton)`
   background-color: ${(props) =>
     props.expanded ? props.theme.colors.darkSnow : 'white'};
   border: none;
+  ${zIndex};
 `


### PR DESCRIPTION
This adds two props to `Map.Control`:
* `index` - Set control stack order
* `onControlReady` - Called after the google map control is created