### PR TITLE
Fix map multimarker rendering unmounted points

### DIFF
--- a/packages/ui-dom/src/Map/index.js
+++ b/packages/ui-dom/src/Map/index.js
@@ -433,7 +433,8 @@ export default class MapContainer extends PureComponent {
   renderCluster = (cluster) => {
     const {getClusterProps, MultiMarker, ClusterMarker} = this.props
     const isMultiMarker = this.multiMarkerEnabled
-    const points = cluster.points.map(this.getMarker)
+    const points = cluster.points.map(this.getMarker).filter(Boolean)
+    if (!points.length) return null
     const clusterProps = {
       isMultiMarker,
       points,


### PR DESCRIPTION
This fixes `Cannot read property 'id' of undefined` in the map component when a cluster marker's child unmounts.