### PR TITLE
feat(places-autocomplete) add validation prop to AddressAutoComplete

### DIFF
--- a/packages/places-autocomplete/AddressAutoComplete/index.jsx
+++ b/packages/places-autocomplete/AddressAutoComplete/index.jsx
@@ -49,7 +49,7 @@ export class AddressAutoComplete extends PureComponent {
   }
 
   loadPlace = async (place) => {
-    const {format, options, onSelect} = this.props
+    const {format, options, onSelect, validate} = this.props
     const endpoint = this.constructor.API_ENDPOINT
     this.setState({loading: true, error: undefined})
     try {
@@ -60,16 +60,12 @@ export class AddressAutoComplete extends PureComponent {
           : options
       )
       const {result} = await response.json()
-      const streetNumber = filterComponent(
-        result.address_components,
-        'street_number'
-      ).long_name
-      const postalCode = filterComponent(
-        result.address_components,
-        'postal_code'
-      ).long_name
-      if (!streetNumber || !postalCode)
-        throw new Error('Não encontramos um endereço válido com esse número.')
+      let error
+      if (
+        validate &&
+        (error = validate(result, filterComponent(result.address_components)))
+      )
+        throw new Error(error)
       const value = format(place, result)
       this.setState({value, focused: false}, () => {
         if (onSelect) onSelect(place, result, value)

--- a/packages/places-autocomplete/helpers.es
+++ b/packages/places-autocomplete/helpers.es
@@ -1,5 +1,6 @@
-export function filterComponent(array, property) {
+export const filterComponent = (components) => (property) => {
   return (
-    array.filter((component) => component.types.includes(property))[0] || {}
-  )
+    components.filter((component) => component.types.includes(property))[0] ||
+    {}
+  ).long_name
 }


### PR DESCRIPTION
Removes default validation, which requires both a postal code and street number, and adds a `validation` prop to `AddressAutoComplete`.