### PR TITLE
Refac/login saga

### DIFF
--- a/packages/login/README.md
+++ b/packages/login/README.md
@@ -12,7 +12,7 @@ or
 npm install --save @emcasa/login
 ```
 
-We basically have to main components one is called LoginPure and the other is LoginSaga. Independently of witch one of these you choose, there are two things that you should know:
+We basically have to main components one is called LoginPure and the other is LoginSaga. Independently of which one of these you choose, there are two things that you should know:
 
 1) The components expects that you pass two functions:
 
@@ -58,7 +58,7 @@ ReactDOM.render(
 
 ### Login Saga
 
-If your application uses redux-saga, you can use this version of login. Witch in addition to place the component somewhere else in your code, you also have to use the `fork` effect to run a saga that you should import. It will be explained next.
+If your application uses redux-saga, you can use this version of login. Which, in addition to place the component somewhere else in your code, you also have to use the `fork` effect to run a saga that you should import. It will be explained next.
 
 - First the import:
 
@@ -90,15 +90,17 @@ ReactDOM.render(
 
 ```
 import {all, fork} from 'redux-saga/effects'
-import libAuthSaga from '@emcasa/login/lib/sagas/authSaga'
+import authSaga from '@emcasa/login/lib/sagas/authSaga'
 
-  function* root() {
-    return yield all([
-      //your other sagas here,
-      fork(libAuthSaga)
-    ])
-  }
-
+function* root() {
+  return yield all([
+    //your other sagas here,
+    fork(authSaga({
+      onSuccess: function* () { /* some success saga */ },
+      onError: function* () { /* some error saga */ }
+    }))
+  ])
+}
 ```
 
 One important this is, is expected that you provide a client from graphql using the redux-saga context with the name: `apolloClient`

--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -56,5 +56,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "peerDependencies": {
+    "react-click-outside": "^3.0.1"
   }
 }

--- a/packages/login/src/redux/modules/auth/saga.js
+++ b/packages/login/src/redux/modules/auth/saga.js
@@ -53,9 +53,14 @@ export function* submitTokenSaga({
   }
 }
 
-export default function* authSaga() {
-  yield all([
-    takeLatest(TYPES.EM_CASA_REQUEST_TOKEN, requestTokenSaga),
-    takeLatest(TYPES.EM_CASA_SUBMIT_TOKEN, submitTokenSaga)
-  ])
+const withOptions = (options) => (saga) => (...args) => saga(...args, options)
+
+export default (options = {}) => {
+  const enhanceSaga = withOptions(options)
+  return function* authSaga() {
+    yield all([
+      takeLatest(TYPES.EM_CASA_REQUEST_TOKEN, enhanceSaga(requestTokenSaga)),
+      takeLatest(TYPES.EM_CASA_SUBMIT_TOKEN, enhanceSaga(submitTokenSaga))
+    ])
+  }
 }

--- a/packages/login/src/redux/modules/auth/saga.js
+++ b/packages/login/src/redux/modules/auth/saga.js
@@ -11,9 +11,9 @@ function* callSequence(fns, ...args) {
   }
 }
 
-export function* requestTokenSaga(
-  {promiseDispatcher, phone, ...action},
-  options = {}
+export const requestTokenSaga = function* _requestTokenSaga(
+  options = {},
+  {promiseDispatcher, phone, ...action}
 ) {
   const client = yield getContext('apolloClient')
   const onError = [options.onError, action.onError, promiseDispatcher.reject]
@@ -43,9 +43,9 @@ export function* requestTokenSaga(
   }
 }
 
-export function* submitTokenSaga(
-  {promiseDispatcher, phone, token, ...action},
-  options = {}
+export const submitTokenSaga = function* _submitTokenSaga(
+  options = {},
+  {promiseDispatcher, phone, token, ...action}
 ) {
   const client = yield getContext('apolloClient')
   const onError = [options.onError, action.onError, promiseDispatcher.reject]
@@ -57,7 +57,7 @@ export function* submitTokenSaga(
   try {
     const {
       data: {signInVerifyAuthenticationCode: response}
-    } = yield* call([client, client.mutate], {
+    } = yield call([client, client.mutate], {
       mutation: SUBMIT_TOKEN_MUTATION,
       variables: {phone: `+55${phone}`, code: token}
     })
@@ -67,14 +67,10 @@ export function* submitTokenSaga(
   }
 }
 
-const withOptions = (options) => (saga) => (...args) => saga(...args, options)
-
-export default (options = {}) => {
-  const enhanceSaga = withOptions(options)
-  return function* authSaga() {
+export default (options = {}) =>
+  function* authSaga() {
     yield all([
-      takeLatest(TYPES.EM_CASA_REQUEST_TOKEN, enhanceSaga(requestTokenSaga)),
-      takeLatest(TYPES.EM_CASA_SUBMIT_TOKEN, enhanceSaga(submitTokenSaga))
+      takeLatest(TYPES.EM_CASA_REQUEST_TOKEN, requestTokenSaga, options),
+      takeLatest(TYPES.EM_CASA_SUBMIT_TOKEN, submitTokenSaga, options)
     ])
   }
-}

--- a/packages/login/src/redux/modules/auth/saga.js
+++ b/packages/login/src/redux/modules/auth/saga.js
@@ -5,8 +5,23 @@ import {
   SUBMIT_TOKEN_MUTATION
 } from '@/graphql/mutations/auth'
 
-export function* requestTokenSaga({promiseDispatcher, phone, onError}) {
+function* callSequence(fns, ...args) {
+  for (const fn of fns) {
+    if (fn) yield call(fn, ...args)
+  }
+}
+
+export function* requestTokenSaga(
+  {promiseDispatcher, phone, ...action},
+  options = {}
+) {
   const client = yield getContext('apolloClient')
+  const onError = [options.onError, action.onError, promiseDispatcher.reject]
+  const onSuccess = [
+    options.onSuccess,
+    action.onSuccess,
+    promiseDispatcher.resolve
+  ]
   try {
     const {
       data: {signInCreateAuthenticationCode: response}
@@ -16,40 +31,39 @@ export function* requestTokenSaga({promiseDispatcher, phone, onError}) {
     })
 
     if (response.enqueued === 'SUCCESS') {
-      yield call(promiseDispatcher.resolve)
+      yield* callSequence(onSuccess)
     } else {
-      yield call(promiseDispatcher.reject, {
+      yield* callSequence(onError, {
         response,
         message: 'unexpected response returned'
       })
     }
   } catch (error) {
-    if (onError) yield call(onError, error)
-    yield call(promiseDispatcher.reject, error)
+    yield* callSequence(onError, error)
   }
 }
 
-export function* submitTokenSaga({
-  promiseDispatcher,
-  phone,
-  token,
-  onError,
-  onSuccess
-}) {
+export function* submitTokenSaga(
+  {promiseDispatcher, phone, token, ...action},
+  options = {}
+) {
   const client = yield getContext('apolloClient')
+  const onError = [options.onError, action.onError, promiseDispatcher.reject]
+  const onSuccess = [
+    options.onSuccess,
+    action.onSuccess,
+    promiseDispatcher.resolve
+  ]
   try {
     const {
       data: {signInVerifyAuthenticationCode: response}
-    } = yield call([client, client.mutate], {
+    } = yield* call([client, client.mutate], {
       mutation: SUBMIT_TOKEN_MUTATION,
       variables: {phone: `+55${phone}`, code: token}
     })
-
-    yield call(onSuccess, response.jwt, response.user)
-    yield call(promiseDispatcher.resolve, response.jwt, response.user)
+    yield* callSequence(onSuccess, response.jwt, response.user)
   } catch (error) {
-    if (onError) yield call(onError, error)
-    yield call(promiseDispatcher.reject, error)
+    yield* callSequence(onError, error)
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13360,7 +13360,7 @@ hoist-non-react-statics@3.3.0:
   dependencies:
     react-is "^16.7.0"
 
-hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
+hoist-non-react-statics@^2.1.1, hoist-non-react-statics@^2.3.1, hoist-non-react-statics@^2.5.0:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
   integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
@@ -20354,6 +20354,13 @@ react-ace@^7.0.2:
     lodash.get "^4.4.2"
     lodash.isequal "^4.5.0"
     prop-types "^15.7.2"
+
+react-click-outside@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/react-click-outside/-/react-click-outside-3.0.1.tgz#6e77e84d2f17afaaac26dbad743cbbf909f5e24c"
+  integrity sha512-d0KWFvBt+esoZUF15rL2UBB7jkeAqLU8L/Ny35oLK6fW6mIbOv/ChD+ExF4sR9PD26kVx+9hNfD0FTIqRZEyRQ==
+  dependencies:
+    hoist-non-react-statics "^2.1.1"
 
 react-clone-referenced-element@^1.0.1:
   version "1.1.0"


### PR DESCRIPTION
- [x] Fix missing dependencies on `@emcasa/login`
- [x] Add options to `@emcasa/login`'s saga
- [x] Update README

This PR brings composition to the login saga by allowing success/error logic to be declared from the saga module instead of the login component.

Take for instance a success callback which sets the jwt to redux-saga's context. With our current implementation this is only possible by passing a saga to the onSuccess callback on the LoginSaga component, which is bad practice:

```js
import {setContext} from 'redux-saga/effects'
import LoginSaga from '@emcasa/login/lib/LoginSaga'

<LoginSaga
  onSuccess={function* (jwt) {
    // help, my callback is a saga!
    yield setContext('jwt', jwt)
  }}
/>	
```

before:
---
saga.js
```js
import {all, fork} from 'redux-saga/effects'
import authSaga from '@emcasa/login/lib/sagas/authSaga'

function* root() {
  return yield all([fork(authSaga)])
}
```

login.js
```js
import LoginSaga from '@emcasa/login/lib/LoginSaga'

<LoginSaga onSuccess={(jwt) => /* set jwt to some cookie */} />
```

after:
---
saga.js
```js
import {all, fork} from 'redux-saga/effects'
import authSaga from '@emcasa/login/lib/sagas/authSaga'

function* root() {
  return yield all([
    fork(authSaga({
      onSuccess(jwt) {/* set jwt to some cookie */}
    })
  ])
}
```

login.js
```js
import LoginSaga from '@emcasa/login/lib/LoginSaga'

<LoginSaga />
```
