### PR TITLE
Fix dependencies on @emcasa/login

### DIFF
--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -31,12 +31,7 @@
   "dependencies": {
     "@babel/runtime": "^7.8.3",
     "@emcasa/ui": "^2.9.11",
-    "@emcasa/ui-dom": "^2.9.11",
-    "graphql-tag": "^2.10.1",
-    "lodash": "^4.17.15",
-    "react-input-mask": "3.0.0-alpha.2",
-    "react-redux": "^7.1.3",
-    "redux-saga": "^1.1.3"
+    "@emcasa/ui-dom": "^2.9.11"
   },
   "devDependencies": {
     "@babel/cli": "7.8.3",
@@ -58,6 +53,11 @@
     "access": "public"
   },
   "peerDependencies": {
+    "graphql-tag": "^2.10.1",
+    "lodash": "^4.17.15",
+    "react-input-mask": ">=3.0.0-alpha.2",
+    "react-redux": "^7.1.3",
+    "redux-saga": "^1.1.3",
     "react-click-outside": "^3.0.1"
   }
 }

--- a/packages/ui-dom/package.json
+++ b/packages/ui-dom/package.json
@@ -30,7 +30,11 @@
     "styled-icons": "8.4.2",
     "styled-system": "5.1.2",
     "supercluster": "6.0.2",
-    "tinycolor2": "1.4.1"
+    "tinycolor2": "1.4.1",
+    "redux-saga": "^1.1.3",
+    "react-redux": "^7.1.3",
+    "react-input-mask": "3.0.0-alpha.2",
+    "graphql-tag": "^2.10.1"
   },
   "devDependencies": {
     "@babel/cli": "7.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12972,9 +12972,9 @@ graphql-request@^1.5.0:
     cross-fetch "2.2.2"
 
 graphql-tag@^2.10.1:
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.1.tgz#10aa41f1cd8fae5373eaf11f1f67260a3cad5e02"
-  integrity sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==
+  version "2.10.3"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.3.tgz#ea1baba5eb8fc6339e4c4cf049dabe522b0edf03"
+  integrity sha512-4FOv3ZKfA4WdOKJeHdz6B3F/vxBLSgmBcGeAFPf4n1F64ltJUvOOerNj0rsJxONQGdhUMynQIvd6LzB+1J5oKA==
 
 graphql-tools@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Redux and graphql related stuff should be peer dependencies to avoid conflict
between versions from this package and the project which includes it.