### PR TITLE
Login fixes

### DIFF
--- a/packages/login/LoginSaga.js
+++ b/packages/login/LoginSaga.js
@@ -13,8 +13,8 @@ const LoginSaga = (props) => (
 )
 
 LoginSaga.propTypes = {
-  onSuccess: PropTypes.func.isRequired,
-  onError: PropTypes.func.isRequired
+  onSuccess: PropTypes.func,
+  onError: PropTypes.func
 }
 
 export default mapAsyncDispatchToProps({

--- a/packages/login/sagas/actions.js
+++ b/packages/login/sagas/actions.js
@@ -1,0 +1,1 @@
+export * from '@/redux/modules/auth/actions'

--- a/packages/login/src/components/login/index.js
+++ b/packages/login/src/components/login/index.js
@@ -108,8 +108,8 @@ Login.defaultProps = {
 Login.propTypes = {
   submitToken: PropTypes.func.isRequired,
   requestToken: PropTypes.func.isRequired,
-  onSuccess: PropTypes.func.isRequired,
-  onError: PropTypes.func.isRequired,
+  onSuccess: PropTypes.func,
+  onError: PropTypes.func,
   children: PropTypes.func
 }
 


### PR DESCRIPTION
- Add export for saga actions from `/lib/sagas/actions` (for testing)
- Remove required callbacks on `<SagaLogin />`. `onError` and `onSuccess` isn't strictly required anymore (since #158).