### PR TITLE
fix(dropdown | placeautocomplete): styles and markup

### DIFF
--- a/packages/places-autocomplete/GoogleMapsAutoComplete/Spinner.jsx
+++ b/packages/places-autocomplete/GoogleMapsAutoComplete/Spinner.jsx
@@ -1,16 +1,14 @@
 import React from 'react'
-import styled from 'styled-components'
-import {themeGet} from '@styled-system/theme-get'
 import PulseLoader from 'react-spinners/PulseLoader'
 import Row from '@emcasa/ui-dom/components/Row'
+import colors from '@emcasa/ui/src/theme/colors'
 
-export default styled(function Spinner(props) {
+const Spinner = () => {
   return (
     <Row alignItems="center" justifyContent="center" p={3}>
-      <PulseLoader {...props} />
+      <PulseLoader size={6} color={colors.grey300} />
     </Row>
   )
-}).attrs({
-  size: 6,
-  color: themeGet('colors.pink')
-})``
+}
+
+export default Spinner

--- a/packages/places-autocomplete/GoogleMapsAutoComplete/index.jsx
+++ b/packages/places-autocomplete/GoogleMapsAutoComplete/index.jsx
@@ -191,21 +191,14 @@ export default class GoogleMapsAutoComplete extends PureComponent {
     return (
       <Dropdown
         focused={focused}
-        label={
-          <Row mr="-10px" flex={1} justifyContent="center" alignItems="center">
-            <Col flex={1}>
-              <Input
-                ref={this.props.inputRef}
-                autoComplete="new-password"
-                value={value}
-                onChange={this.changeText}
-                {...pick(props, inputProps)}
-                {...props.inputProps}
-              />
-            </Col>
-            {renderControls && renderControls(this.state)}
-          </Row>
-        }
+        inputProps={{
+          ref: this.props.inputRef,
+          autoComplete: "new-password",
+          value: value,
+          onChange: this.changeText,
+          ...pick(props, inputProps),
+          ...props.inputProps
+        }}
         onFocus={this.focus}
         onBlur={this.blur}
         onChange={this.selectPlace}

--- a/packages/ui-dom/src/Dropdown/Button.js
+++ b/packages/ui-dom/src/Dropdown/Button.js
@@ -99,7 +99,9 @@ const DropdownButton = ({
       {searchInputProps ? (
         <Button as="input" placeholder={placeholder} {...buttonProps} />
       ) : (
-        <Button {...buttonProps}>{children}</Button>
+        <Button type="button" {...buttonProps}>
+          {children}
+        </Button>
       )}
       <ButtonIcon
         focused={focused}

--- a/packages/ui-dom/src/Dropdown/Option.js
+++ b/packages/ui-dom/src/Dropdown/Option.js
@@ -10,6 +10,7 @@ const Button = styled.li`
   padding: 0 ${themeGet('space.4')}px;
   box-sizing: border-box;
   overflow: hidden;
+  font-family: ${themeGet('fontFamily')};
   font-size: ${themeGet('buttonFontSize.0')}px;
   color: ${themeGet('colors.grey900')};
   line-height: 20px;


### PR DESCRIPTION
- Ajuste no Spinner para evitar o erro:
```
Functions that are interpolated in css calls will be stringified.
If you want to have a css call based on props, create a function that returns a css call like this
let dynamicStyle = (props) => css`color: ${props.color}`
It can be called directly with props or interpolated in a styled call like this
let SomeComponent = styled('div')`${dynamicStyle}`
```

- Substitui o `Input` do `GoogleMapsAutoComplete` pelo `inputProps` do `Dropdown`

- Adiciona `type="button"` no botão do `Dropdown` para evitar que ele dispare o `submit` do `<form>`

- Adiciona `font-family` para evitar que apareça com font do sistema — somente no Garagem.