### PR TITLE
(*): remove and replace react-spinners

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "react-pose": "4.0.8",
     "react-redux": "^7.1.3",
     "react-responsive": "8.0.1",
-    "react-spinners": "0.6.1",
     "redux-saga": "^1.1.3",
     "styled-components": "5.0.0-beta.9"
   },

--- a/packages/image-upload/UploadTarget/styles.jsx
+++ b/packages/image-upload/UploadTarget/styles.jsx
@@ -3,7 +3,123 @@ import styled from 'styled-components'
 import Text from '@emcasa/ui-dom/components/Text'
 import {breakpoint} from '@emcasa/ui/lib/styles'
 import Card from '../Card'
-import {SpinnerSVG} from '../../places-autocomplete/GoogleMapsAutoComplete/Spinner'
+
+// We should create a Spinner component. It's the same Spinner from packages/places-autocomplete/GoogleMapsAutoComplete/Spinner.jsx
+
+const SpinnerSVG = () => (
+  <svg preserveAspectRatio="xMidYMid" height={18} viewBox="6 40 88 20">
+    <circle cx="84" cy="50" r="10" fill="#c0c2cc">
+      <animate
+        attributeName="r"
+        repeatCount="indefinite"
+        dur="0.625s"
+        calcMode="spline"
+        keyTimes="0;1"
+        values="5;0"
+        keySplines="0 0.5 0.5 1"
+        begin="0s"
+      ></animate>
+      <animate
+        attributeName="fill"
+        repeatCount="indefinite"
+        dur="2.5s"
+        calcMode="discrete"
+        keyTimes="0;0.25;0.5;0.75;1"
+        values="#c0c2cc;#c0c2cc;#c0c2cc;#c0c2cc;#c0c2cc"
+        begin="0s"
+      ></animate>
+    </circle>
+    <circle cx="16" cy="50" r="10" fill="#c0c2cc">
+      <animate
+        attributeName="r"
+        repeatCount="indefinite"
+        dur="2.5s"
+        calcMode="spline"
+        keyTimes="0;0.25;0.5;0.75;1"
+        values="0;0;5;5;5"
+        keySplines="0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1"
+        begin="0s"
+      ></animate>
+      <animate
+        attributeName="cx"
+        repeatCount="indefinite"
+        dur="2.5s"
+        calcMode="spline"
+        keyTimes="0;0.25;0.5;0.75;1"
+        values="16;16;16;50;84"
+        keySplines="0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1"
+        begin="0s"
+      ></animate>
+    </circle>
+    <circle cx="50" cy="50" r="10" fill="#c0c2cc">
+      <animate
+        attributeName="r"
+        repeatCount="indefinite"
+        dur="2.5s"
+        calcMode="spline"
+        keyTimes="0;0.25;0.5;0.75;1"
+        values="0;0;5;5;5"
+        keySplines="0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1"
+        begin="-0.625s"
+      ></animate>
+      <animate
+        attributeName="cx"
+        repeatCount="indefinite"
+        dur="2.5s"
+        calcMode="spline"
+        keyTimes="0;0.25;0.5;0.75;1"
+        values="16;16;16;50;84"
+        keySplines="0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1"
+        begin="-0.625s"
+      ></animate>
+    </circle>
+    <circle cx="84" cy="50" r="10" fill="#c0c2cc">
+      <animate
+        attributeName="r"
+        repeatCount="indefinite"
+        dur="2.5s"
+        calcMode="spline"
+        keyTimes="0;0.25;0.5;0.75;1"
+        values="0;0;5;5;5"
+        keySplines="0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1"
+        begin="-1.25s"
+      ></animate>
+      <animate
+        attributeName="cx"
+        repeatCount="indefinite"
+        dur="2.5s"
+        calcMode="spline"
+        keyTimes="0;0.25;0.5;0.75;1"
+        values="16;16;16;50;84"
+        keySplines="0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1"
+        begin="-1.25s"
+      ></animate>
+    </circle>
+    <circle cx="16" cy="50" r="10" fill="#c0c2cc">
+      <animate
+        attributeName="r"
+        repeatCount="indefinite"
+        dur="2.5s"
+        calcMode="spline"
+        keyTimes="0;0.25;0.5;0.75;1"
+        values="0;0;5;5;5"
+        keySplines="0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1"
+        begin="-1.875s"
+      ></animate>
+      <animate
+        attributeName="cx"
+        repeatCount="indefinite"
+        dur="2.5s"
+        calcMode="spline"
+        keyTimes="0;0.25;0.5;0.75;1"
+        values="16;16;16;50;84"
+        keySplines="0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1"
+        begin="-1.875s"
+      ></animate>
+    </circle>
+  </svg>
+)
+
 export const UploadCard = styled(Card)`
   ${({isActive}) =>
     isActive && {

--- a/packages/image-upload/UploadTarget/styles.jsx
+++ b/packages/image-upload/UploadTarget/styles.jsx
@@ -6,7 +6,7 @@ import Card from '../Card'
 
 // We should create a Spinner component. It's the same Spinner from packages/places-autocomplete/GoogleMapsAutoComplete/Spinner.jsx
 
-const SpinnerSVG = () => (
+const LoaderDotsSVG = () => (
   <svg preserveAspectRatio="xMidYMid" height={18} viewBox="6 40 88 20">
     <circle cx="84" cy="50" r="10" fill="#c0c2cc">
       <animate
@@ -142,7 +142,7 @@ export const UploadCard = styled(Card)`
 
 export const Spinner = styled(({className, style}) => (
   <div className={className} style={style}>
-    <SpinnerSVG />
+    <LoaderDotsSVG />
   </div>
 ))`
   display: flex;

--- a/packages/image-upload/UploadTarget/styles.jsx
+++ b/packages/image-upload/UploadTarget/styles.jsx
@@ -2,9 +2,8 @@ import React from 'react'
 import styled from 'styled-components'
 import Text from '@emcasa/ui-dom/components/Text'
 import {breakpoint} from '@emcasa/ui/lib/styles'
-import PulseLoader from 'react-spinners/PulseLoader'
 import Card from '../Card'
-
+import {SpinnerSVG} from '../../places-autocomplete/GoogleMapsAutoComplete/Spinner'
 export const UploadCard = styled(Card)`
   ${({isActive}) =>
     isActive && {
@@ -25,14 +24,11 @@ export const UploadCard = styled(Card)`
   }
 `
 
-export const Spinner = styled(({className, style, ...props}) => (
+export const Spinner = styled(({className, style}) => (
   <div className={className} style={style}>
-    <PulseLoader {...props} />
+    <SpinnerSVG />
   </div>
-)).attrs(({theme}) => ({
-  size: 6,
-  color: theme.colors['pink']
-}))`
+))`
   display: flex;
   justify-content: center;
   align-items: center;

--- a/packages/image-upload/package.json
+++ b/packages/image-upload/package.json
@@ -27,8 +27,7 @@
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "react-dnd": "^9.3.4",
-    "react-spinners": "^0.5.4"
+    "react-dnd": "^9.3.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/places-autocomplete/GoogleMapsAutoComplete/Spinner.jsx
+++ b/packages/places-autocomplete/GoogleMapsAutoComplete/Spinner.jsx
@@ -3,7 +3,7 @@ import Row from '@emcasa/ui-dom/components/Row'
 
 // We should create a Spinner component. It's the same Spinner from packages/image-upload/UploadTarget/styles.jsx
 
-const SpinnerSVG = () => (
+const LoaderDotsSVG = () => (
   <svg preserveAspectRatio="xMidYMid" height={18} viewBox="6 40 88 20">
     <circle cx="84" cy="50" r="10" fill="#c0c2cc">
       <animate
@@ -120,7 +120,7 @@ const SpinnerSVG = () => (
 const Spinner = () => {
   return (
     <Row alignItems="center" justifyContent="center" p={3}>
-      <SpinnerSVG />
+      <LoaderDotsSVG />
     </Row>
   )
 }

--- a/packages/places-autocomplete/GoogleMapsAutoComplete/Spinner.jsx
+++ b/packages/places-autocomplete/GoogleMapsAutoComplete/Spinner.jsx
@@ -1,7 +1,9 @@
 import React from 'react'
 import Row from '@emcasa/ui-dom/components/Row'
 
-export const SpinnerSVG = () => (
+// We should create a Spinner component. It's the same Spinner from packages/image-upload/UploadTarget/styles.jsx
+
+const SpinnerSVG = () => (
   <svg preserveAspectRatio="xMidYMid" height={18} viewBox="6 40 88 20">
     <circle cx="84" cy="50" r="10" fill="#c0c2cc">
       <animate

--- a/packages/places-autocomplete/GoogleMapsAutoComplete/Spinner.jsx
+++ b/packages/places-autocomplete/GoogleMapsAutoComplete/Spinner.jsx
@@ -1,13 +1,124 @@
 import React from 'react'
-import PulseLoader from 'react-spinners/PulseLoader'
 import Row from '@emcasa/ui-dom/components/Row'
 
-const GREY300 = '#c0c2cc' // "import colors from '@emcasa/ui/src/theme/colors'" isn't working on /web and /garagem-blocks. Error: SyntaxError: Unexpected token 'export'("export default {").
+export const SpinnerSVG = () => (
+  <svg preserveAspectRatio="xMidYMid" height={18} viewBox="6 40 88 20">
+    <circle cx="84" cy="50" r="10" fill="#c0c2cc">
+      <animate
+        attributeName="r"
+        repeatCount="indefinite"
+        dur="0.625s"
+        calcMode="spline"
+        keyTimes="0;1"
+        values="5;0"
+        keySplines="0 0.5 0.5 1"
+        begin="0s"
+      ></animate>
+      <animate
+        attributeName="fill"
+        repeatCount="indefinite"
+        dur="2.5s"
+        calcMode="discrete"
+        keyTimes="0;0.25;0.5;0.75;1"
+        values="#c0c2cc;#c0c2cc;#c0c2cc;#c0c2cc;#c0c2cc"
+        begin="0s"
+      ></animate>
+    </circle>
+    <circle cx="16" cy="50" r="10" fill="#c0c2cc">
+      <animate
+        attributeName="r"
+        repeatCount="indefinite"
+        dur="2.5s"
+        calcMode="spline"
+        keyTimes="0;0.25;0.5;0.75;1"
+        values="0;0;5;5;5"
+        keySplines="0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1"
+        begin="0s"
+      ></animate>
+      <animate
+        attributeName="cx"
+        repeatCount="indefinite"
+        dur="2.5s"
+        calcMode="spline"
+        keyTimes="0;0.25;0.5;0.75;1"
+        values="16;16;16;50;84"
+        keySplines="0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1"
+        begin="0s"
+      ></animate>
+    </circle>
+    <circle cx="50" cy="50" r="10" fill="#c0c2cc">
+      <animate
+        attributeName="r"
+        repeatCount="indefinite"
+        dur="2.5s"
+        calcMode="spline"
+        keyTimes="0;0.25;0.5;0.75;1"
+        values="0;0;5;5;5"
+        keySplines="0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1"
+        begin="-0.625s"
+      ></animate>
+      <animate
+        attributeName="cx"
+        repeatCount="indefinite"
+        dur="2.5s"
+        calcMode="spline"
+        keyTimes="0;0.25;0.5;0.75;1"
+        values="16;16;16;50;84"
+        keySplines="0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1"
+        begin="-0.625s"
+      ></animate>
+    </circle>
+    <circle cx="84" cy="50" r="10" fill="#c0c2cc">
+      <animate
+        attributeName="r"
+        repeatCount="indefinite"
+        dur="2.5s"
+        calcMode="spline"
+        keyTimes="0;0.25;0.5;0.75;1"
+        values="0;0;5;5;5"
+        keySplines="0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1"
+        begin="-1.25s"
+      ></animate>
+      <animate
+        attributeName="cx"
+        repeatCount="indefinite"
+        dur="2.5s"
+        calcMode="spline"
+        keyTimes="0;0.25;0.5;0.75;1"
+        values="16;16;16;50;84"
+        keySplines="0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1"
+        begin="-1.25s"
+      ></animate>
+    </circle>
+    <circle cx="16" cy="50" r="10" fill="#c0c2cc">
+      <animate
+        attributeName="r"
+        repeatCount="indefinite"
+        dur="2.5s"
+        calcMode="spline"
+        keyTimes="0;0.25;0.5;0.75;1"
+        values="0;0;5;5;5"
+        keySplines="0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1"
+        begin="-1.875s"
+      ></animate>
+      <animate
+        attributeName="cx"
+        repeatCount="indefinite"
+        dur="2.5s"
+        calcMode="spline"
+        keyTimes="0;0.25;0.5;0.75;1"
+        values="16;16;16;50;84"
+        keySplines="0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1;0 0.5 0.5 1"
+        begin="-1.875s"
+      ></animate>
+    </circle>
+  </svg>
+)
 
 const Spinner = () => {
   return (
     <Row alignItems="center" justifyContent="center" p={3}>
-      <PulseLoader size={6} color={GREY300} />
+      <SpinnerSVG />
     </Row>
   )
 }

--- a/packages/places-autocomplete/package.json
+++ b/packages/places-autocomplete/package.json
@@ -24,9 +24,7 @@
     "jest": "23.6.0",
     "prop-types": "^15.7.2"
   },
-  "peerDependencies": {
-    "react-spinners": "^0.5.4"
-  },
+  "peerDependencies": {},
   "publishConfig": {
     "access": "public"
   }

--- a/packages/ui-dom/src/Dropdown/Button.js
+++ b/packages/ui-dom/src/Dropdown/Button.js
@@ -134,7 +134,7 @@ const DropdownButton = ({
       )}
       {!hideTrailingIcon && (
         <TrailingIcon
-          focused={focused}
+          focused={focused ? 1 : 0}
           name="chevron-down"
           color="dark"
           size={height === 'short' ? 12 : 16}

--- a/packages/ui-dom/src/Dropdown/Container.js
+++ b/packages/ui-dom/src/Dropdown/Container.js
@@ -21,7 +21,8 @@ const Listbox = styled.ul`
     focused ? 'translateY(0)' : 'translateY(-12px)'};
   transition: opacity ${({focused}) => (focused ? '0.2s' : '0.15s')} linear,
     transform 0.5s cubic-bezier(0.4, 0.2, 0, 1),
-    max-height ${({focused}) => (focused ? '0s' : '0.5s cubic-bezier(0.4, 0.2, 0, 1)')};
+    max-height
+      ${({focused}) => (focused ? '0s' : '0.5s cubic-bezier(0.4, 0.2, 0, 1)')};
   display: flex;
   flex-direction: column;
   box-sizing: border-box;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1567,7 +1567,7 @@
     "@emotion/stylis" "^0.7.1"
     "@emotion/utils" "^0.8.2"
 
-"@emotion/core@10.0.27", "@emotion/core@^10.0.14", "@emotion/core@^10.0.15", "@emotion/core@^10.0.16":
+"@emotion/core@10.0.27", "@emotion/core@^10.0.14", "@emotion/core@^10.0.16":
   version "10.0.27"
   resolved "https://registry.yarnpkg.com/@emotion/core/-/core-10.0.27.tgz#7c3f78be681ab2273f3bf11ca3e2edc4a9dd1fdc"
   integrity sha512-XbD5R36pVbohQMnKfajHv43g8EbN4NHdF6Zh9zg/C0nr0jqwOw3gYnC07Xj3yG43OYSRyrGsoQ5qPwc8ycvLZw==
@@ -20872,13 +20872,6 @@ react-simple-code-editor@^0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/react-simple-code-editor/-/react-simple-code-editor-0.10.0.tgz#73e7ac550a928069715482aeb33ccba36efe2373"
   integrity sha512-bL5W5mAxSW6+cLwqqVWY47Silqgy2DKDTR4hDBrLrUqC5BXc29YVx17l2IZk5v36VcDEq1Bszu2oHm1qBwKqBA==
-
-react-spinners@0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/react-spinners/-/react-spinners-0.6.1.tgz#c4f31a1d0e4c85cdb1785a8bdbe17311cf269b0a"
-  integrity sha512-bMCOvwAlzuIDC6Zh69E1EbyKUbvWSl4sMzLXOgnsF4Q/kkAnCNaonWyskMFytbaJSYxBCCOiaeCH2moDJ5y5Pg==
-  dependencies:
-    "@emotion/core" "^10.0.15"
 
 react-split-pane@^0.1.84:
   version "0.1.89"


### PR DESCRIPTION
Descrição

Vamos remover a dependência do `react-spinners` e substituir os `loaders` por um SVG.

# Preview

![spinner](https://user-images.githubusercontent.com/320157/155005673-79869635-334d-4175-8daa-da50ab5484e1.gif)
![Screen Recording 2022-02-18 at 18 17 18](https://user-images.githubusercontent.com/320157/155005815-d46f7e22-4dbe-4552-8892-f8a4a0527ddb.gif)

